### PR TITLE
Bugfix: use screen resolution to scale the area cleared by prefs_clear()

### DIFF
--- a/src/apple2/screen.c
+++ b/src/apple2/screen.c
@@ -38,6 +38,9 @@ extern uint16_t mul0375(uint16_t val);
 extern void (*io_recv_serial_flow_on)(void);
 extern void (*io_recv_serial_flow_off)(void);
 
+// size of scaled PLATO screen
+padPt actualSize = {256, 192};
+
 #define FONTPTR(a) (((a << 1) + a) << 1)
 #define mul05(a) ((a>>1)+12)
 

--- a/src/apple2enh/screen.c
+++ b/src/apple2enh/screen.c
@@ -41,6 +41,9 @@ extern uint16_t mul0375(uint16_t val);
 extern void (*io_recv_serial_flow_on)(void);
 extern void (*io_recv_serial_flow_off)(void);
 
+// size of scaled PLATO screen
+padPt actualSize = {512, 192};
+
 #define FONTPTR(a) (((a << 1) + a) << 1)
 #define mul05(a) ((a>>1)+12)
 

--- a/src/atari/screen.c
+++ b/src/atari/screen.c
@@ -45,6 +45,9 @@ extern void (*io_recv_serial_flow_on)(void);
 extern void (*io_recv_serial_flow_off)(void);
 extern padPt TTYLoc;
 
+// size of scaled PLATO screen
+padPt actualSize = {320, 192};
+
 extern void RenderGlyph(void);
 
 /**

--- a/src/c128/screen.c
+++ b/src/c128/screen.c
@@ -53,6 +53,10 @@ extern uint8_t CharHigh;
 extern padBool FastText; /* protocol.c */
 extern padPt TTYLoc;
 
+// size of scaled PLATO screen
+// we can't use a constant for this since it depends on which driver we load
+padPt actualSize;
+
 extern void (*io_recv_serial_flow_on)(void);
 extern void (*io_recv_serial_flow_off)(void);
 
@@ -106,6 +110,10 @@ void screen_load_driver(void)
       exit(1);
       break;
   }
+
+  // use scaling factors to set actual screen size
+  actualSize.x = SCALEX(PLATOSize.x);
+  actualSize.y = SCALEY(0);
 }
 
 /**

--- a/src/c64/screen.c
+++ b/src/c64/screen.c
@@ -45,7 +45,8 @@ extern uint16_t mul0375(uint16_t val);
 extern void (*io_recv_serial_flow_on)(void);
 extern void (*io_recv_serial_flow_off)(void);
 
-
+// size of scaled PLATO screen
+padPt actualSize = {320, 192};
 
 #define FONTPTR(a) (((a << 1) + a) << 1)
 

--- a/src/prefs_base.c
+++ b/src/prefs_base.c
@@ -50,6 +50,8 @@ extern padBool ModeBold;
 extern padBool Rotate;
 extern padBool Reverse;
 
+extern uint8_t FONT_SIZE_Y;
+
 uint8_t temp_val[8];
 uint8_t ch;
 uint8_t prefs_need_updating;
@@ -383,7 +385,7 @@ void prefs_clear(void)
 #else
   c=tgi_getcolor();
   tgi_setcolor(TGI_COLOR_BLACK);
-  tgi_bar(0,185,319,191);
+  tgi_bar(0,actualSize.y-1-FONT_SIZE_Y,tgi_getmaxx(),actualSize.y-1);
   tgi_setcolor(c);
   ShowPLATO("\n\v",2);
 #endif

--- a/src/screen.h
+++ b/src/screen.h
@@ -12,6 +12,9 @@
 
 #include "protocol.h"
 
+// Size of scaled PLATO screen
+extern padPt actualSize;
+
 /**
  * screen_init() - Set up the screen
  */


### PR DESCRIPTION
prefs_clear() was doing the wrong thing on screen resolutions that weren't 320x200 pixels (i.e. a 192 pixel PLATO screen). This was most obvious in the 640x480 VDC mode on the C128, where prefs_clear() erased a block halfway up the screen, and not the preferences area at all!

Make sure to double-check the constants that I've used for the new `actualSize` variable in the various platforms' `screen.c` files. I'm pretty sure I've got them right based on the scaling factors used, but I'm only really familiar with the Commodore platforms here.