### PR TITLE
Use screen_block_draw to clear prefs area

### DIFF
--- a/src/apple2/screen.c
+++ b/src/apple2/screen.c
@@ -38,9 +38,6 @@ extern uint16_t mul0375(uint16_t val);
 extern void (*io_recv_serial_flow_on)(void);
 extern void (*io_recv_serial_flow_off)(void);
 
-// size of scaled PLATO screen
-padPt actualSize = {256, 192};
-
 #define FONTPTR(a) (((a << 1) + a) << 1)
 #define mul05(a) ((a>>1)+12)
 

--- a/src/apple2enh/screen.c
+++ b/src/apple2enh/screen.c
@@ -41,9 +41,6 @@ extern uint16_t mul0375(uint16_t val);
 extern void (*io_recv_serial_flow_on)(void);
 extern void (*io_recv_serial_flow_off)(void);
 
-// size of scaled PLATO screen
-padPt actualSize = {512, 192};
-
 #define FONTPTR(a) (((a << 1) + a) << 1)
 #define mul05(a) ((a>>1)+12)
 

--- a/src/atari/screen.c
+++ b/src/atari/screen.c
@@ -45,9 +45,6 @@ extern void (*io_recv_serial_flow_on)(void);
 extern void (*io_recv_serial_flow_off)(void);
 extern padPt TTYLoc;
 
-// size of scaled PLATO screen
-padPt actualSize = {320, 192};
-
 extern void RenderGlyph(void);
 
 /**

--- a/src/c128/screen.c
+++ b/src/c128/screen.c
@@ -53,10 +53,6 @@ extern uint8_t CharHigh;
 extern padBool FastText; /* protocol.c */
 extern padPt TTYLoc;
 
-// size of scaled PLATO screen
-// we can't use a constant for this since it depends on which driver we load
-padPt actualSize;
-
 extern void (*io_recv_serial_flow_on)(void);
 extern void (*io_recv_serial_flow_off)(void);
 
@@ -110,10 +106,6 @@ void screen_load_driver(void)
       exit(1);
       break;
   }
-
-  // use scaling factors to set actual screen size
-  actualSize.x = SCALEX(PLATOSize.x);
-  actualSize.y = SCALEY(0);
 }
 
 /**

--- a/src/c64/screen.c
+++ b/src/c64/screen.c
@@ -45,8 +45,7 @@ extern uint16_t mul0375(uint16_t val);
 extern void (*io_recv_serial_flow_on)(void);
 extern void (*io_recv_serial_flow_off)(void);
 
-// size of scaled PLATO screen
-padPt actualSize = {320, 192};
+
 
 #define FONTPTR(a) (((a << 1) + a) << 1)
 

--- a/src/io_base.c
+++ b/src/io_base.c
@@ -23,7 +23,7 @@
 uint8_t xoff_enabled;
 uint8_t io_load_successful=false;
 
-void io_recv_serial_flow_dummy(void);
+static void io_recv_serial_flow_dummy(void);
 
 uint8_t (*io_serial_buffer_size)(void);
 void (*io_recv_serial_flow_off)(void) = io_recv_serial_flow_dummy;
@@ -43,7 +43,7 @@ static struct ser_params params = {
   SER_HS_HW
 };
 
-void io_recv_serial_flow_dummy(void) {}
+static void io_recv_serial_flow_dummy(void) {}
 
 /**
  * io_init() - Set-up the I/O

--- a/src/io_base.c
+++ b/src/io_base.c
@@ -23,9 +23,11 @@
 uint8_t xoff_enabled;
 uint8_t io_load_successful=false;
 
+void io_recv_serial_flow_dummy(void);
+
 uint8_t (*io_serial_buffer_size)(void);
-void (*io_recv_serial_flow_off)(void);
-void (*io_recv_serial_flow_on)(void);
+void (*io_recv_serial_flow_off)(void) = io_recv_serial_flow_dummy;
+void (*io_recv_serial_flow_on)(void) = io_recv_serial_flow_dummy;
 
 static uint8_t ch=0;
 static uint8_t io_res;
@@ -41,6 +43,8 @@ static struct ser_params params = {
   SER_HS_HW
 };
 
+void io_recv_serial_flow_dummy(void) {}
+
 /**
  * io_init() - Set-up the I/O
  */
@@ -52,7 +56,7 @@ void io_init(void)
 
   if (io_res==SER_ERR_OK)
     io_load_successful=true;
-  
+
   xoff_enabled=false;
 
   if (io_load_successful)
@@ -67,7 +71,6 @@ void io_init(void)
       prefs_clear();
       prefs_display(recv_buffer);
     }
-  
 }
 
 /**

--- a/src/prefs_base.c
+++ b/src/prefs_base.c
@@ -50,8 +50,6 @@ extern padBool ModeBold;
 extern padBool Rotate;
 extern padBool Reverse;
 
-extern uint8_t FONT_SIZE_Y;
-
 uint8_t temp_val[8];
 uint8_t ch;
 uint8_t prefs_need_updating;
@@ -377,18 +375,13 @@ unsigned char prefs_get_key_matching1(const char* matches)
  */
 void prefs_clear(void)
 {
-  uint8_t c;
-#ifdef __APPLE2ENH__
-  hue(DHGR_COLOR_BLACK);
-  dhbar(0,185,519,191);
-  hue(DHGR_COLOR_WHITE);
-#else
-  c=tgi_getcolor();
-  tgi_setcolor(TGI_COLOR_BLACK);
-  tgi_bar(0,actualSize.y-1-FONT_SIZE_Y,tgi_getmaxx(),actualSize.y-1);
-  tgi_setcolor(c);
-  ShowPLATO("\n\v",2);
-#endif
+  padPt p1 = {0, 16};
+  padPt p2 = {511, 0};
+  CurModeSave = CurMode;
+  CurMode = ModeErase;
+  screen_block_draw(&p1, &p2);
+  CurMode = CurModeSave;
+  screen_set_pen_mode();
 }
 
 /**

--- a/src/screen.h
+++ b/src/screen.h
@@ -12,9 +12,6 @@
 
 #include "protocol.h"
 
-// Size of scaled PLATO screen
-extern padPt actualSize;
-
 /**
  * screen_init() - Set up the screen
  */


### PR DESCRIPTION
Based on [@greg-king5's comment on PR #40](https://github.com/tschak909/platoterm64/pull/40#issuecomment-533891395), I reworked `prefs_clear` to just use `screen_block_draw`, which does all the scaling for us, and got rid of all the redundant scaling logic that I added (and the special-case ifdef for the Apple 2).

As a side effect, since `screen_block_draw` asserts flow control, it was necessary to add a dummy flow-control function, that the flow on/off function pointers can point at until the drivers are loaded.